### PR TITLE
Add login and signup pages with basic auth

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,30 +1,37 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
 import HomePage from "./pages/home/index";
 import MoviesPage from "./pages/movies/index";
 import MovieDetailPage from "./pages/movies/detail/index";
 import BookingPage from "./pages/booking/index";
+import LoginPage from "./pages/login";
+import SignUpPage from "./pages/signup";
 import NotFoundPage from "./pages/not-found/index";
 
 function App() {
   return (
-    <Router>
-      <Header />
+    <AuthProvider>
+      <Router>
+        <Header />
 
-      <main>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/movies" element={<MoviesPage />} />
-          <Route path="/movies/:slug" element={<MovieDetailPage />} />
-          <Route path="/booking/*" element={<BookingPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </main>
+        <main>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/movies" element={<MoviesPage />} />
+            <Route path="/movies/:slug" element={<MovieDetailPage />} />
+            <Route path="/booking/*" element={<BookingPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignUpPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </main>
 
-      <Footer />
-    </Router>
+        <Footer />
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,24 @@
+import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
-import App from './App';
+import Header from './components/layout/Header';
 
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+// Minimal mock for react-router-dom to avoid ESM loading issues in Jest
+jest.mock(
+  'react-router-dom',
+  () => ({
+    BrowserRouter: ({ children }) => <div>{children}</div>,
+    Routes: ({ children }) => <div>{children}</div>,
+    Route: () => null,
+    Link: ({ children }) => <a href="#">{children}</a>,
+    NavLink: ({ children }) => <a href="#">{children}</a>,
+  }),
+  { virtual: true }
+);
+
+jest.mock('react-slick', () => () => <div />);
+
+test('renders header logo', () => {
+  render(<Header />);
+  const logoElement = screen.getByRole('link', { name: /cine mate/i });
+  expect(logoElement).toBeInTheDocument();
 });

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,18 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+
+  const login = () => setIsLoggedIn(true);
+  const logout = () => setIsLoggedIn(false);
+
+  return (
+    <AuthContext.Provider value={{ isLoggedIn, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import styles from './index.module.css';
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTo = location.state?.from || '/';
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login();
+    navigate(redirectTo, { replace: true });
+  };
+
+  return (
+    <div className={styles['login-page']}>
+      <form className={styles['login-form']} onSubmit={handleSubmit}>
+        <h2 className={styles['login-form__title']}>Log In</h2>
+        <label className={styles['login-form__label']}>
+          Email
+          <input
+            className={styles['login-form__input']}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label className={styles['login-form__label']}>
+          Password
+          <input
+            className={styles['login-form__input']}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit" className={styles['login-form__submit']}>
+          Log In
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/login/index.module.css
+++ b/src/pages/login/index.module.css
@@ -1,0 +1,61 @@
+.login-page {
+  padding-top: 100px;
+  padding-bottom: 40px;
+  display: flex;
+  justify-content: center;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.login-form__title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.login-form__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.login-form__input {
+  background-color: transparent;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: var(--color-light);
+  font-family: var(--font-family-base);
+  font-size: 14px;
+  padding: 8px 12px;
+  transition: border-color var(--transition-speed);
+}
+
+.login-form__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.login-form__submit {
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: var(--color-dark);
+  padding: 8px 20px;
+  border-radius: 4px;
+  font-family: var(--font-family-base);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--transition-speed), border-color var(--transition-speed);
+}
+
+.login-form__submit:hover,
+.login-form__submit:focus {
+  background-color: #e07b00;
+  border-color: #e07b00;
+  outline: none;
+}

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -1,0 +1,50 @@
+import React, { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../contexts/AuthContext';
+import styles from './index.module.css';
+
+export default function SignUpPage() {
+  const { login } = useAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const navigate = useNavigate();
+  const location = useLocation();
+  const redirectTo = location.state?.from || '/';
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login();
+    navigate(redirectTo, { replace: true });
+  };
+
+  return (
+    <div className={styles['signup-page']}>
+      <form className={styles['signup-form']} onSubmit={handleSubmit}>
+        <h2 className={styles['signup-form__title']}>Sign Up</h2>
+        <label className={styles['signup-form__label']}>
+          Email
+          <input
+            className={styles['signup-form__input']}
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </label>
+        <label className={styles['signup-form__label']}>
+          Password
+          <input
+            className={styles['signup-form__input']}
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </label>
+        <button type="submit" className={styles['signup-form__submit']}>
+          Sign Up
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/src/pages/signup/index.module.css
+++ b/src/pages/signup/index.module.css
@@ -1,0 +1,61 @@
+.signup-page {
+  padding-top: 100px;
+  padding-bottom: 40px;
+  display: flex;
+  justify-content: center;
+}
+
+.signup-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.signup-form__title {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.signup-form__label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.signup-form__input {
+  background-color: transparent;
+  border: 1px solid #444;
+  border-radius: 4px;
+  color: var(--color-light);
+  font-family: var(--font-family-base);
+  font-size: 14px;
+  padding: 8px 12px;
+  transition: border-color var(--transition-speed);
+}
+
+.signup-form__input:focus {
+  outline: none;
+  border-color: var(--color-primary);
+}
+
+.signup-form__submit {
+  background-color: var(--color-primary);
+  border: 1px solid var(--color-primary);
+  color: var(--color-dark);
+  padding: 8px 20px;
+  border-radius: 4px;
+  font-family: var(--font-family-base);
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color var(--transition-speed), border-color var(--transition-speed);
+}
+
+.signup-form__submit:hover,
+.signup-form__submit:focus {
+  background-color: #e07b00;
+  border-color: #e07b00;
+  outline: none;
+}


### PR DESCRIPTION
## Summary
- introduce `AuthContext` for simple authentication state
- add signup and login pages following folder conventions
- register `/signup` and `/login` routes in `App.js`
- update tests with minimal routing mocks

## Testing
- `bun run test`
- `bun run lint`

------
https://chatgpt.com/codex/tasks/task_e_684a8f15d9f48322a3cbcb73c8bd0762