### PR TITLE
Add auth context with login/signup pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,7 +6,10 @@ import HomePage from "./pages/home/index";
 import MoviesPage from "./pages/movies/index";
 import MovieDetailPage from "./pages/movies/detail/index";
 import BookingPage from "./pages/booking/index";
+import LoginPage from "./pages/login";
+import SignupPage from "./pages/signup";
 import NotFoundPage from "./pages/not-found/index";
+import ProtectedRoute from "./components/common/ProtectedRoute";
 
 function App() {
   return (
@@ -18,7 +21,16 @@ function App() {
           <Route path="/" element={<HomePage />} />
           <Route path="/movies" element={<MoviesPage />} />
           <Route path="/movies/:slug" element={<MovieDetailPage />} />
-          <Route path="/booking/*" element={<BookingPage />} />
+          <Route
+            path="/booking/*"
+            element={
+              <ProtectedRoute>
+                <BookingPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/signup" element={<SignupPage />} />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </main>

--- a/src/components/common/ProtectedRoute/index.jsx
+++ b/src/components/common/ProtectedRoute/index.jsx
@@ -1,0 +1,14 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../../../contexts/AuthContext";
+
+export default function ProtectedRoute({ children }) {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/signup" state={{ from: location }} replace />;
+  }
+
+  return children;
+}

--- a/src/components/layout/Header/index.jsx
+++ b/src/components/layout/Header/index.jsx
@@ -2,52 +2,71 @@
 import React from "react";
 import { NavLink, Link } from "react-router-dom";
 import styles from "./index.module.css";
+import { useAuth } from "../../../contexts/AuthContext";
 
-const Header = () => (
-  <header className={styles.header}>
-    <div className={styles.left}>
-      <Link to="/" className={styles.logo}>
-        Cine<span className={styles["logo--gradient"]}>mate</span>
-      </Link>
-      <nav className={styles.nav}>
-        <NavLink
-          to="/movies"
-          className={({ isActive }) =>
-            isActive ? `${styles.navLink} ${styles.activeLink}` : styles.navLink
-          }
-        >
-          Movies
-        </NavLink>
-        <NavLink
-          to="/experience"
-          className={({ isActive }) =>
-            isActive ? `${styles.navLink} ${styles.activeLink}` : styles.navLink
-          }
-        >
-          Experience
-        </NavLink>
-        <NavLink
-          to="/menu"
-          className={({ isActive }) =>
-            isActive ? `${styles.navLink} ${styles.activeLink}` : styles.navLink
-          }
-        >
-          Menu
-        </NavLink>
-      </nav>
-    </div>
-    <div className={styles.actions}>
-      <Link to="/login" className={styles.link}>
-        Log in
-      </Link>
-      <Link to="/signup" className={styles.link}>
-        Sign up
-      </Link>
-      <Link to="/quick-booking" className={styles.quickBooking}>
-        Quick booking
-      </Link>
-    </div>
-  </header>
-);
+const Header = () => {
+  const { user, logout } = useAuth();
+
+  return (
+    <header className={styles.header}>
+      <div className={styles.left}>
+        <Link to="/" className={styles.logo}>
+          Cine<span className={styles["logo--gradient"]}>mate</span>
+        </Link>
+        <nav className={styles.nav}>
+          <NavLink
+            to="/movies"
+            className={({ isActive }) =>
+              isActive
+                ? `${styles.navLink} ${styles.activeLink}`
+                : styles.navLink
+            }
+          >
+            Movies
+          </NavLink>
+          <NavLink
+            to="/experience"
+            className={({ isActive }) =>
+              isActive
+                ? `${styles.navLink} ${styles.activeLink}`
+                : styles.navLink
+            }
+          >
+            Experience
+          </NavLink>
+          <NavLink
+            to="/menu"
+            className={({ isActive }) =>
+              isActive
+                ? `${styles.navLink} ${styles.activeLink}`
+                : styles.navLink
+            }
+          >
+            Menu
+          </NavLink>
+        </nav>
+      </div>
+      <div className={styles.actions}>
+        {user ? (
+          <button onClick={() => logout()} className={styles.link}>
+            Log out
+          </button>
+        ) : (
+          <>
+            <Link to="/login" className={styles.link}>
+              Log in
+            </Link>
+            <Link to="/signup" className={styles.link}>
+              Sign up
+            </Link>
+          </>
+        )}
+        <Link to="/quick-booking" className={styles.quickBooking}>
+          Quick booking
+        </Link>
+      </div>
+    </header>
+  );
+};
 
 export default Header;

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,40 @@
+import React, { createContext, useContext, useState } from "react";
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    try {
+      const saved = localStorage.getItem("user");
+      return saved ? JSON.parse(saved) : null;
+    } catch (e) {
+      return null;
+    }
+  });
+
+  const login = (userData, callback) => {
+    setUser(userData);
+    try {
+      localStorage.setItem("user", JSON.stringify(userData));
+    } catch (e) {}
+    if (callback) callback();
+  };
+
+  const logout = (callback) => {
+    setUser(null);
+    try {
+      localStorage.removeItem("user");
+    } catch (e) {}
+    if (callback) callback();
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,11 @@ import "./index.css";
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App";
+import { AuthProvider } from "./contexts/AuthContext";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
-root.render(<App />);
-
+root.render(
+  <AuthProvider>
+    <App />
+  </AuthProvider>,
+);

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const from = location.state?.from?.pathname || "/";
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // fake authentication, store email only
+    login({ email }, () => navigate(from, { replace: true }));
+  };
+
+  return (
+    <div className="page" style={{ padding: "40px" }}>
+      <h2>Login</h2>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+      >
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit">Login</button>
+      </form>
+      <p>
+        Don't have an account? <Link to="/signup">Sign up</Link>
+      </p>
+    </div>
+  );
+}

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -1,0 +1,48 @@
+import React, { useState } from "react";
+import { useLocation, useNavigate, Link } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+
+export default function SignupPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const from = location.state?.from?.pathname || "/";
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // simple sign up -> log user in
+    login({ email }, () => navigate(from, { replace: true }));
+  };
+
+  return (
+    <div className="page" style={{ padding: "40px" }}>
+      <h2>Sign Up</h2>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: "flex", flexDirection: "column", gap: "8px" }}
+      >
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+        />
+        <button type="submit">Sign Up</button>
+      </form>
+      <p>
+        Already have an account? <Link to="/login">Login</Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement `AuthProvider`/`useAuth` hook with localStorage persistence
- create simple login and signup pages
- add routes for authentication and protect booking routes
- add `ProtectedRoute` helper
- show logout link in header when authenticated

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9b68235c8322a1dc68594dd818a3