### PR TITLE
Move auth inline styles to CSS modules

### DIFF
--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useLocation, useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
+import styles from "./index.module.css";
 
 export default function LoginPage() {
   const { login } = useAuth();
@@ -18,18 +19,16 @@ export default function LoginPage() {
   };
 
   return (
-    <div className="page" style={{ padding: "40px" }}>
+    <div className={`page ${styles["login-page"]}`}>
       <h2>Login</h2>
-      <form
-        onSubmit={handleSubmit}
-        style={{ display: "flex", flexDirection: "column", gap: "8px" }}
-      >
+      <form onSubmit={handleSubmit} className={styles["login-page__form"]}>
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
+          className="input"
         />
         <input
           type="password"
@@ -37,8 +36,11 @@ export default function LoginPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
+          className="input"
         />
-        <button type="submit">Login</button>
+        <button type="submit" className="btn btn--primary">
+          Login
+        </button>
       </form>
       <p>
         Don't have an account? <Link to="/signup">Sign up</Link>

--- a/src/pages/login/index.module.css
+++ b/src/pages/login/index.module.css
@@ -1,0 +1,11 @@
+/* src/pages/login/index.module.css */
+
+.page.login-page {
+  padding: 40px;
+}
+
+.login-page__form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { useLocation, useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
+import styles from "./index.module.css";
 
 export default function SignupPage() {
   const { login } = useAuth();
@@ -18,18 +19,16 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="page" style={{ padding: "40px" }}>
+    <div className={`page ${styles["signup-page"]}`}>
       <h2>Sign Up</h2>
-      <form
-        onSubmit={handleSubmit}
-        style={{ display: "flex", flexDirection: "column", gap: "8px" }}
-      >
+      <form onSubmit={handleSubmit} className={styles["signup-page__form"]}>
         <input
           type="email"
           placeholder="Email"
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
+          className="input"
         />
         <input
           type="password"
@@ -37,8 +36,11 @@ export default function SignupPage() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
+          className="input"
         />
-        <button type="submit">Sign Up</button>
+        <button type="submit" className="btn btn--primary">
+          Sign Up
+        </button>
       </form>
       <p>
         Already have an account? <Link to="/login">Login</Link>

--- a/src/pages/signup/index.module.css
+++ b/src/pages/signup/index.module.css
@@ -1,0 +1,11 @@
+/* src/pages/signup/index.module.css */
+
+.page.signup-page {
+  padding: 40px;
+}
+
+.signup-page__form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}


### PR DESCRIPTION
## Summary
- create CSS modules for login and signup
- move inline styles into the modules
- import modules and apply `.btn` and `.input` classes

## Testing
- `npm install`
- `CI=true npm test` *(fails: Cannot find module 'react-router-dom')*

------
https://chatgpt.com/codex/tasks/task_e_684a9e9833bc8322908ab3769834e98e