### PR TITLE
Add guest login option

### DIFF
--- a/src/components/common/ProtectedRoute/index.jsx
+++ b/src/components/common/ProtectedRoute/index.jsx
@@ -6,7 +6,9 @@ export default function ProtectedRoute({ children }) {
   const { user } = useAuth();
   const location = useLocation();
 
-  if (!user) {
+  const isGuest = user?.guest;
+
+  if (!user && !isGuest) {
     return <Navigate to="/signup" state={{ from: location }} replace />;
   }
 

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -20,6 +20,15 @@ export function AuthProvider({ children }) {
     if (callback) callback();
   };
 
+  const loginAsGuest = (callback) => {
+    const guestUser = { guest: true };
+    setUser(guestUser);
+    try {
+      localStorage.setItem("user", JSON.stringify(guestUser));
+    } catch (e) {}
+    if (callback) callback();
+  };
+
   const logout = (callback) => {
     setUser(null);
     try {
@@ -29,7 +38,7 @@ export function AuthProvider({ children }) {
   };
 
   return (
-    <AuthContext.Provider value={{ user, login, logout }}>
+    <AuthContext.Provider value={{ user, login, loginAsGuest, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/src/docs/documentation.md
+++ b/src/docs/documentation.md
@@ -10,13 +10,14 @@
 2. [Folder Structure](#folder-structure)
 3. [Pages & Routing](#pages--routing)
 4. [State Management](#state-management)
-5. [Data & API Layer](#data--api-layer)
-6. [Styling System](#styling-system)
-7. [Testing Strategy](#testing-strategy)
-8. [CI / CD Pipeline](#ci--cd-pipeline)
-9. [Deployment Guide](#deployment-guide)
-10. [Extending the Project](#extending-the-project)
-11. [Glossary](#glossary)
+5. [Guest Sessions](#guest-sessions)
+6. [Data & API Layer](#data--api-layer)
+7. [Styling System](#styling-system)
+8. [Testing Strategy](#testing-strategy)
+9. [CI / CD Pipeline](#ci--cd-pipeline)
+10. [Deployment Guide](#deployment-guide)
+11. [Extending the Project](#extending-the-project)
+12. [Glossary](#glossary)
 
 ---
 
@@ -76,6 +77,12 @@ Routes are declared in `src/index.jsx`. Add a new page by:
 | Remote data           | Placeholder fetch util    | future: SWR / React Query |
 
 > No Redux here; the app is intentionally lightweight. Introduce Zustand or React Query if the domain grows.
+
+---
+
+## Guest Sessions
+
+Visitors can skip account creation by choosing **Continue as guest** on the login or signup pages. The app stores `{ guest: true }` in `localStorage` and `ProtectedRoute` treats this as an authenticated session. Logging out removes the entry.
 
 ---
 
@@ -153,4 +160,4 @@ Adjust `vite.config.js → base` if deploying under a sub‑folder.
 
 ---
 
-*Last updated: 2025‑06‑10*
+*Last updated: 2025‑06‑12*

--- a/src/docs/guest-users.md
+++ b/src/docs/guest-users.md
@@ -1,0 +1,3 @@
+# Guest Users
+
+Cinemate supports a lightweight guest mode for quick access. Click **Continue as guest** on the login or signup page to enter without creating an account. The app stores `{ guest: true }` in `localStorage` and `ProtectedRoute` considers this authenticated. Use the Log out action to clear guest data.

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 
 export default function LoginPage() {
-  const { login } = useAuth();
+  const { login, loginAsGuest } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const [email, setEmail] = useState("");
@@ -15,6 +15,10 @@ export default function LoginPage() {
     e.preventDefault();
     // fake authentication, store email only
     login({ email }, () => navigate(from, { replace: true }));
+  };
+
+  const handleGuest = () => {
+    loginAsGuest(() => navigate(from, { replace: true }));
   };
 
   return (
@@ -40,6 +44,9 @@ export default function LoginPage() {
         />
         <button type="submit">Login</button>
       </form>
+      <button onClick={handleGuest} style={{ marginTop: "8px" }}>
+        Continue as guest
+      </button>
       <p>
         Don't have an account? <Link to="/signup">Sign up</Link>
       </p>

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate, Link } from "react-router-dom";
 import { useAuth } from "../../contexts/AuthContext";
 
 export default function SignupPage() {
-  const { login } = useAuth();
+  const { login, loginAsGuest } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
   const [email, setEmail] = useState("");
@@ -15,6 +15,10 @@ export default function SignupPage() {
     e.preventDefault();
     // simple sign up -> log user in
     login({ email }, () => navigate(from, { replace: true }));
+  };
+
+  const handleGuest = () => {
+    loginAsGuest(() => navigate(from, { replace: true }));
   };
 
   return (
@@ -40,6 +44,9 @@ export default function SignupPage() {
         />
         <button type="submit">Sign Up</button>
       </form>
+      <button onClick={handleGuest} style={{ marginTop: "8px" }}>
+        Continue as guest
+      </button>
       <p>
         Already have an account? <Link to="/login">Login</Link>
       </p>


### PR DESCRIPTION
## Summary
- extend `AuthContext` with `loginAsGuest`
- add guest buttons on login and signup pages
- accept guest sessions in `ProtectedRoute`
- document new behaviour in docs

## Testing
- `bun run lint` *(fails: ESLint couldn't find config)*
- `bun run test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9ea587b08322ab3f2bd4903e5be1