### PR TITLE
Add background blur to auth pages

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,30 +1,37 @@
 import React from "react";
 import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import { AuthProvider } from "./contexts/AuthContext";
 import Header from "./components/layout/Header";
 import Footer from "./components/layout/Footer";
 import HomePage from "./pages/home/index";
 import MoviesPage from "./pages/movies/index";
 import MovieDetailPage from "./pages/movies/detail/index";
 import BookingPage from "./pages/booking/index";
+import LoginPage from "./pages/login";
+import SignupPage from "./pages/signup";
 import NotFoundPage from "./pages/not-found/index";
 
 function App() {
   return (
-    <Router>
-      <Header />
+    <AuthProvider>
+      <Router>
+        <Header />
 
-      <main>
-        <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/movies" element={<MoviesPage />} />
-          <Route path="/movies/:slug" element={<MovieDetailPage />} />
-          <Route path="/booking/*" element={<BookingPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-        </Routes>
-      </main>
+        <main>
+          <Routes>
+            <Route path="/" element={<HomePage />} />
+            <Route path="/movies" element={<MoviesPage />} />
+            <Route path="/movies/:slug" element={<MovieDetailPage />} />
+            <Route path="/booking/*" element={<BookingPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+          </Routes>
+        </main>
 
-      <Footer />
-    </Router>
+        <Footer />
+      </Router>
+    </AuthProvider>
   );
 }
 

--- a/src/components/layout/Header/index.jsx
+++ b/src/components/layout/Header/index.jsx
@@ -1,14 +1,17 @@
 // src/components/Header/Header.js
 import React from "react";
 import { NavLink, Link } from "react-router-dom";
+import { useAuth } from "../../../contexts/AuthContext";
 import styles from "./index.module.css";
 
-const Header = () => (
-  <header className={styles.header}>
-    <div className={styles.left}>
-      <Link to="/" className={styles.logo}>
-        Cine<span className={styles["logo--gradient"]}>mate</span>
-      </Link>
+const Header = () => {
+  const { user, logout } = useAuth();
+  return (
+    <header className={styles.header}>
+      <div className={styles.left}>
+        <Link to="/" className={styles.logo}>
+          Cine<span className={styles["logo--gradient"]}>mate</span>
+        </Link>
       <nav className={styles.nav}>
         <NavLink
           to="/movies"
@@ -35,19 +38,34 @@ const Header = () => (
           Menu
         </NavLink>
       </nav>
-    </div>
-    <div className={styles.actions}>
-      <Link to="/login" className={styles.link}>
-        Log in
-      </Link>
-      <Link to="/signup" className={styles.link}>
-        Sign up
-      </Link>
-      <Link to="/quick-booking" className={styles.quickBooking}>
-        Quick booking
-      </Link>
-    </div>
-  </header>
-);
+      </div>
+      <div className={styles.actions}>
+        {user ? (
+          <>
+            <span className={styles.link}>{user.email}</span>
+            <button
+              onClick={logout}
+              className={`${styles.link} ${styles.buttonLink}`}
+            >
+              Log out
+            </button>
+          </>
+        ) : (
+          <>
+            <Link to="/login" className={styles.link}>
+              Log in
+            </Link>
+            <Link to="/signup" className={styles.link}>
+              Sign up
+            </Link>
+          </>
+        )}
+        <Link to="/quick-booking" className={styles.quickBooking}>
+          Quick booking
+        </Link>
+      </div>
+    </header>
+  );
+};
 
 export default Header;

--- a/src/components/layout/Header/index.module.css
+++ b/src/components/layout/Header/index.module.css
@@ -100,6 +100,15 @@
   color: var(--color-primary);
 }
 
+.buttonLink {
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
 .quickBooking {
   font-size: 0.9rem;
   font-weight: 500;

--- a/src/components/movies/ShowtimesList/index.jsx
+++ b/src/components/movies/ShowtimesList/index.jsx
@@ -1,11 +1,13 @@
 /*  src/components/movies/ShowtimesList/index.jsx  */
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../contexts/AuthContext';
 import movies from '../../../data/movies';
 import styles from './index.module.css';
 
 export default function ShowtimesList() {
   const navigate = useNavigate();
+  const { user } = useAuth();
   const [activeTrailer, setActiveTrailer] = useState(null);
 
   return (
@@ -63,11 +65,15 @@ export default function ShowtimesList() {
                       className={`${styles['showtime-pill']} ${
                         styles[`format-${format.toLowerCase()}`]
                       }`}
-                      onClick={() =>
-                        navigate('/booking/tickets', {
-                          state: { movieSlug: m.slug, time, format },
-                        })
+                    onClick={() => {
+                      const dest = '/booking/tickets';
+                      const destState = { movieSlug: m.slug, time, format };
+                      if (!user) {
+                        navigate('/login', { state: { from: { pathname: dest, state: destState } } });
+                      } else {
+                        navigate(dest, { state: destState });
                       }
+                    }}
                     >
                       <span className={styles['pill__time']}>{time}</span>
                       <span className={styles['pill__format']}>

--- a/src/components/movies/Slider/index.jsx
+++ b/src/components/movies/Slider/index.jsx
@@ -1,6 +1,7 @@
 /*  src/components/movies/Slider/index.jsx  */
 import React from "react";
 import { useNavigate } from "react-router-dom";
+import { useAuth } from "../../../contexts/AuthContext";
 import SlickSlider from "react-slick";
 import moviesData from "../../../data/movies";
 import styles from "./index.module.css";
@@ -10,6 +11,7 @@ import "slick-carousel/slick/slick-theme.css";
 
 export default function Slider() {
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   /* custom arrows have to see `styles`, поэтому объявляем их внутри */
   const PrevArrow = ({ onClick }) => (
@@ -74,7 +76,14 @@ export default function Slider() {
 
                 <button
                   className={styles["slide__buy-button"]}
-                  onClick={() => navigate(`/movies/${movie.slug}`)}
+                  onClick={() => {
+                    const dest = `/movies/${movie.slug}`;
+                    if (!user) {
+                      navigate('/login', { state: { from: { pathname: dest } } });
+                    } else {
+                      navigate(dest);
+                    }
+                  }}
                 >
                   Buy tickets
                 </button>

--- a/src/contexts/AuthContext.jsx
+++ b/src/contexts/AuthContext.jsx
@@ -1,0 +1,36 @@
+import React, { createContext, useContext, useEffect, useState } from "react";
+
+const AuthContext = createContext();
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("user");
+    if (saved) {
+      try {
+        setUser(JSON.parse(saved));
+      } catch {
+        setUser(null);
+      }
+    }
+  }, []);
+
+  const login = (data) => {
+    setUser(data);
+    localStorage.setItem("user", JSON.stringify(data));
+  };
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem("user");
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export const useAuth = () => useContext(AuthContext);

--- a/src/pages/login/index.jsx
+++ b/src/pages/login/index.jsx
@@ -1,0 +1,57 @@
+import React, { useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+import styles from "./index.module.css";
+
+export default function LoginPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || "/";
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login({ email });
+    navigate(from, { replace: true, state: location.state?.from?.state });
+  };
+
+  return (
+    <div className={styles["auth-page"]}>
+      <div className={styles["auth-page__container"]}>
+        <form className={styles["auth-form"]} onSubmit={handleSubmit}>
+          <h2 className={styles["auth-title"]}>Log in</h2>
+          <label className={styles["auth-label"]}>
+            Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={styles["auth-input"]}
+            required
+          />
+        </label>
+        <label className={styles["auth-label"]}>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={styles["auth-input"]}
+            required
+          />
+        </label>
+        <button type="submit" className={`btn btn--primary ${styles["auth-button"]}`}>
+          Log in
+        </button>
+        <Link to="/signup" className={styles["auth-link"]}>
+          No account? Sign up
+        </Link>
+        </form>
+      </div>
+      <div className={styles["auth-page__blur-container"]} />
+    </div>
+  );
+}

--- a/src/pages/login/index.module.css
+++ b/src/pages/login/index.module.css
@@ -1,0 +1,88 @@
+.auth-page {
+  position: relative;
+  padding-top: 100px;
+  padding-bottom: 40px;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  background-color: var(--color-dark);
+  overflow: hidden;
+}
+
+.auth-page__container {
+  position: relative;
+  z-index: 2;
+}
+
+.auth-form {
+  background-color: var(--color-dark-alt);
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-title {
+  font-size: 24px;
+  margin-bottom: 24px;
+  color: var(--color-light);
+  text-align: center;
+}
+
+.auth-label {
+  display: block;
+  margin-bottom: 16px;
+  color: var(--color-light);
+  font-size: 14px;
+}
+
+.auth-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background-color: var(--color-dark);
+  color: var(--color-light);
+  outline: none;
+  transition: border-color var(--transition-speed);
+}
+
+.auth-input:focus {
+  border-color: var(--color-primary);
+}
+
+.auth-button {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  font-size: 16px;
+  padding: 10px 24px;
+}
+
+.auth-link {
+  display: block;
+  margin-top: 16px;
+  text-align: center;
+}
+
+.auth-page__blur-container {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  margin-left: -50vw;
+  width: 100vw;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.8) 0%,
+      rgba(0, 0, 0, 0) 70%
+    ),
+    url("../../assets/images/backgrounds/showa-bg.jpg") center bottom / cover
+      no-repeat;
+  filter: blur(60px) brightness(1.3);
+  opacity: 0.6;
+}

--- a/src/pages/movies/detail/index.jsx
+++ b/src/pages/movies/detail/index.jsx
@@ -2,6 +2,7 @@
 
 import React from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
+import { useAuth } from "../../../contexts/AuthContext";
 import moviesData from "../../../data/movies";
 import ShowtimeNav from "../../../components/movies/ShowtimeNav";
 import styles from "./index.module.css";
@@ -12,6 +13,7 @@ import showaBg from "../../../assets/images/backgrounds/showa-bg.jpg";
 export default function MovieDetailPage() {
   const { slug } = useParams();
   const navigate = useNavigate();
+  const { user } = useAuth();
 
   const movie = moviesData.find((m) => m.slug === slug);
   if (!movie) {
@@ -180,9 +182,15 @@ export default function MovieDetailPage() {
               </h2>
               <button
                 className={`btn btn--primary ${styles["movie-detail-page__buy-button"]}`}
-                onClick={() =>
-                  navigate("/booking/tickets", { state: { movieSlug: slug } })
-                }
+                onClick={() => {
+                  const dest = "/booking/tickets";
+                  const destState = { movieSlug: slug };
+                  if (!user) {
+                    navigate("/login", { state: { from: { pathname: dest, state: destState } } });
+                  } else {
+                    navigate(dest, { state: destState });
+                  }
+                }}
               >
                 Buy tickets
               </button>
@@ -200,11 +208,15 @@ export default function MovieDetailPage() {
                   <button
                     key={i}
                     className={`${styles.sessionPill} ${pillClass}`}
-                    onClick={() =>
-                      navigate("/booking/tickets", {
-                        state: { movieSlug: slug, time, format },
-                      })
-                    }
+                    onClick={() => {
+                      const dest = "/booking/tickets";
+                      const destState = { movieSlug: slug, time, format };
+                      if (!user) {
+                        navigate("/login", { state: { from: { pathname: dest, state: destState } } });
+                      } else {
+                        navigate(dest, { state: destState });
+                      }
+                    }}
                   >
                     <span className={styles.sessionTime}>{time}</span>
                     <span className={styles.sessionFormat}>{format}</span>

--- a/src/pages/signup/index.jsx
+++ b/src/pages/signup/index.jsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import { useNavigate, useLocation, Link } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+import styles from "./index.module.css";
+
+export default function SignupPage() {
+  const { login } = useAuth();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const from = location.state?.from?.pathname || "/";
+
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    login({ email, name });
+    navigate(from, { replace: true, state: location.state?.from?.state });
+  };
+
+  return (
+    <div className={styles["auth-page"]}>
+      <div className={styles["auth-page__container"]}>
+        <form className={styles["auth-form"]} onSubmit={handleSubmit}>
+          <h2 className={styles["auth-title"]}>Sign up</h2>
+        <label className={styles["auth-label"]}>
+          Name
+          <input
+            type="text"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className={styles["auth-input"]}
+            required
+          />
+        </label>
+        <label className={styles["auth-label"]}>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className={styles["auth-input"]}
+            required
+          />
+        </label>
+        <label className={styles["auth-label"]}>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className={styles["auth-input"]}
+            required
+          />
+        </label>
+        <button type="submit" className={`btn btn--primary ${styles["auth-button"]}`}>
+          Sign up
+        </button>
+        <Link to="/login" className={styles["auth-link"]}>
+          Already have an account? Log in
+        </Link>
+        </form>
+      </div>
+      <div className={styles["auth-page__blur-container"]} />
+    </div>
+  );
+}

--- a/src/pages/signup/index.module.css
+++ b/src/pages/signup/index.module.css
@@ -1,0 +1,88 @@
+.auth-page {
+  position: relative;
+  padding-top: 100px;
+  padding-bottom: 40px;
+  min-height: 100vh;
+  display: flex;
+  justify-content: center;
+  background-color: var(--color-dark);
+  overflow: hidden;
+}
+
+.auth-page__container {
+  position: relative;
+  z-index: 2;
+}
+
+.auth-form {
+  background-color: var(--color-dark-alt);
+  border-radius: 8px;
+  padding: 24px;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
+  width: 100%;
+  max-width: 400px;
+}
+
+.auth-title {
+  font-size: 24px;
+  margin-bottom: 24px;
+  color: var(--color-light);
+  text-align: center;
+}
+
+.auth-label {
+  display: block;
+  margin-bottom: 16px;
+  color: var(--color-light);
+  font-size: 14px;
+}
+
+.auth-input {
+  width: 100%;
+  padding: 8px 12px;
+  font-size: 14px;
+  border: 1px solid #555;
+  border-radius: 4px;
+  background-color: var(--color-dark);
+  color: var(--color-light);
+  outline: none;
+  transition: border-color var(--transition-speed);
+}
+
+.auth-input:focus {
+  border-color: var(--color-primary);
+}
+
+.auth-button {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  font-size: 16px;
+  padding: 10px 24px;
+}
+
+.auth-link {
+  display: block;
+  margin-top: 16px;
+  text-align: center;
+}
+
+.auth-page__blur-container {
+  position: absolute;
+  left: 50%;
+  top: 0;
+  margin-left: -50vw;
+  width: 100vw;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  background: linear-gradient(
+      to top,
+      rgba(0, 0, 0, 0.8) 0%,
+      rgba(0, 0, 0, 0) 70%
+    ),
+    url("../../assets/images/backgrounds/showa-bg.jpg") center bottom / cover
+      no-repeat;
+  filter: blur(60px) brightness(1.3);
+  opacity: 0.6;
+}


### PR DESCRIPTION
## Summary
- wrap login and signup forms in containers
- add blurred background image like movie pages

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aaab297908322895d4821f31853ea