### PR TITLE
Improve mobile styles

### DIFF
--- a/src/components/layout/Footer/index.module.css
+++ b/src/components/layout/Footer/index.module.css
@@ -125,3 +125,18 @@
   font-size: 15px;
   color: #888;
 }
+@media (max-width: 600px) {
+  .footer__container {
+    grid-template-columns: 1fr;
+    text-align: center;
+  }
+  .footer__subscribeForm {
+    flex-direction: column;
+  }
+  .footer__socialLinks {
+    justify-content: center;
+  }
+  .footer__links {
+    align-items: center;
+  }
+}

--- a/src/components/layout/Header/index.module.css
+++ b/src/components/layout/Header/index.module.css
@@ -32,7 +32,10 @@
   font-weight: 600;
   color: #b3b3b3; /* "Cine" */
   text-decoration: none;
-  transition: color 0.2s ease, filter 0.2s ease, text-shadow 0.2s ease;
+  transition:
+    color 0.2s ease,
+    filter 0.2s ease,
+    text-shadow 0.2s ease;
 }
 
 /* 2) При ховере по всему лого — и по белой, и по градиентной части */
@@ -53,7 +56,8 @@
 .logo--gradient:hover,
 .logo:hover .logo--gradient {
   /* лёгкое свечение того же цвета, что и градиент */
-  text-shadow: 0 0 8px rgba(247, 143, 30, 0.878),
+  text-shadow:
+    0 0 8px rgba(247, 143, 30, 0.878),
     0 0 16px rgba(234, 135, 6, 0.4);
 }
 
@@ -117,8 +121,10 @@
   text-decoration: none;
   border: 2px solid var(--color-primary);
   border-radius: 10px;
-  transition: background-color var(--transition-speed),
-    color var(--transition-speed), border-color var(--transition-speed);
+  transition:
+    background-color var(--transition-speed),
+    color var(--transition-speed),
+    border-color var(--transition-speed);
 }
 
 .quickBooking:hover,
@@ -142,4 +148,29 @@
 /* Активная ссылка всегда приоритетнее */
 .activeLink {
   color: var(--color-primary) !important;
+}
+@media (max-width: 600px) {
+  .header {
+    flex-direction: column;
+    align-items: flex-start;
+    padding: 16px;
+  }
+  .left {
+    flex-direction: column;
+    gap: 16px;
+    width: 100%;
+  }
+  .actions {
+    width: 100%;
+    justify-content: space-between;
+    margin-top: 12px;
+  }
+  .nav {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  .quickBooking {
+    width: 100%;
+    text-align: center;
+  }
 }

--- a/src/components/movies/ShowtimesList/index.module.css
+++ b/src/components/movies/ShowtimesList/index.module.css
@@ -21,11 +21,8 @@
   width: 100vw;
   height: 1000px; /* подкорректируйте по желанию */
   background:
-    /* сверху чёрная полупрозрачность -> прозрачность */ linear-gradient(
-      to top,
-      rgba(0, 0, 0, 0.8) 0%,
-      rgba(0, 0, 0, 0) 70%
-    ),
+    /* сверху чёрная полупрозрачность -> прозрачность */
+    linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0) 70%),
     /* собственно картинка */
       url("../../../assets/images/backgrounds/showtimes-bg.jpg") center bottom /
       cover no-repeat;
@@ -58,6 +55,7 @@
   gap: 1.5rem;
   padding-bottom: 2rem;
   border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  align-items: flex-start;
 }
 
 /* блок с постером и кнопкой ▶ */
@@ -231,4 +229,28 @@
   color: #fff;
   cursor: pointer;
   z-index: 1;
+}
+
+@media (max-width: 600px) {
+  .showtimes-list__item {
+    flex-direction: column;
+    gap: 1rem;
+  }
+  .showtimes-list__poster {
+    width: 100%;
+    max-width: 280px;
+    margin: 0 auto;
+  }
+  .showtimes-list__content {
+    width: 100%;
+  }
+  .showtimes-list__times {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    flex-wrap: unset;
+  }
+  .showtime-pill {
+    width: 100%;
+    justify-content: center;
+  }
 }

--- a/src/components/movies/Slider/index.module.css
+++ b/src/components/movies/Slider/index.module.css
@@ -95,7 +95,10 @@
   font-weight: 600;
   color: rgba(255, 166, 0, 0.95);
   cursor: pointer;
-  transition: background-color 0.2s, color 0.2s, border-color 0.2s;
+  transition:
+    background-color 0.2s,
+    color 0.2s,
+    border-color 0.2s;
 }
 .slide__buy-button:hover {
   background-color: rgba(255, 166, 0, 0.16);
@@ -125,7 +128,10 @@
   justify-content: center;
   border-radius: 50%;
 
-  transition: color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease,
+  transition:
+    color 0.2s ease,
+    background-color 0.2s ease,
+    box-shadow 0.2s ease,
     transform 0.2s ease;
 }
 
@@ -194,4 +200,27 @@
   line-height: 1;
   vertical-align: middle;
   margin-left: 4px; /* чуть отступ от времени */
+}
+
+@media (max-width: 600px) {
+  .custom-arrow {
+    width: 48px;
+    height: 48px;
+    font-size: 32px;
+  }
+  .custom-prev {
+    left: 16px;
+  }
+  .custom-next {
+    right: 16px;
+  }
+  .slide__text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .slide__buy-button {
+    position: static;
+    margin-top: 8px;
+  }
 }

--- a/src/components/movies/TrailerCarousel/index.module.css
+++ b/src/components/movies/TrailerCarousel/index.module.css
@@ -211,6 +211,26 @@
   }
 }
 
+@media (max-width: 600px) {
+  .carouselContainer {
+    height: 24rem;
+  }
+  :global(.slick-list) {
+    min-height: 24rem;
+  }
+  .customArrow {
+    width: 40px;
+    height: 40px;
+    font-size: 28px;
+  }
+  .customPrev {
+    left: 8px;
+  }
+  .customNext {
+    right: 8px;
+  }
+}
+
 .ratingBadge {
   display: inline-block;
   padding: 2px 6px;

--- a/src/pages/booking/index.module.css
+++ b/src/pages/booking/index.module.css
@@ -1,11 +1,10 @@
 /* src/pages/BookingPage.css */
 
 .booking-page {
-  padding-top: 100px; 
-  padding-bottom: 423px; 
+  padding-top: 100px;
+  padding-bottom: 423px;
   background-color: var(--color-dark);
   color: var(--color-light);
-  
 }
 
 .booking-page__container {
@@ -31,4 +30,13 @@
       no-repeat;
   filter: blur(60px) brightness(1.3);
   opacity: 0.3;
+}
+@media (max-width: 600px) {
+  .booking-page {
+    padding-top: 80px;
+    padding-bottom: 200px;
+  }
+  .booking-page__container {
+    padding: 0 16px;
+  }
 }

--- a/src/pages/login/index.module.css
+++ b/src/pages/login/index.module.css
@@ -78,3 +78,14 @@
   margin-top: 16px;
   text-align: center;
 }
+@media (max-width: 600px) {
+  .auth-page {
+    padding-top: 80px;
+    padding-bottom: 20px;
+  }
+  .auth-form {
+    max-width: none;
+    width: 90%;
+    padding: 16px;
+  }
+}

--- a/src/pages/movies/detail/index.module.css
+++ b/src/pages/movies/detail/index.module.css
@@ -165,8 +165,10 @@
   color: var(--color-dark);
   border-radius: 4px;
   cursor: pointer;
-  transition: background-color var(--transition-speed),
-    color var(--transition-speed), border-color var(--transition-speed);
+  transition:
+    background-color var(--transition-speed),
+    color var(--transition-speed),
+    border-color var(--transition-speed);
 }
 
 .movie-detail-page__buy-button:hover,
@@ -398,9 +400,23 @@
   pointer-events: none;
   z-index: 1; /* меньше, чем у __container */
 
-  background: linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, transparent 70%),
+  background:
+    linear-gradient(to top, rgba(0, 0, 0, 0.8) 0%, transparent 70%),
     var(--bg-image) center bottom / cover no-repeat;
 
   filter: blur(60px) brightness(1);
   opacity: 0.6;
+}
+@media (max-width: 600px) {
+  .movie-detail-page__gallery-item {
+    flex: 0 0 100%;
+    max-width: 100%;
+  }
+  .movie-detail-page__showtimes {
+    position: static;
+    margin-top: 24px;
+  }
+  .showtimes-body {
+    width: 100%;
+  }
 }

--- a/src/pages/movies/index.module.css
+++ b/src/pages/movies/index.module.css
@@ -98,6 +98,30 @@
     margin-top: 1rem;
     max-width: none;
   }
+  .movies-page__controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+  .controls__right {
+    width: 100%;
+    gap: 0.5rem;
+  }
+  .search-wrapper {
+    width: 100%;
+    left: 0;
+    flex: 1;
+  }
+  .filters-button {
+    flex-shrink: 0;
+    margin-top: 0.5rem;
+  }
+  .movies-page__status-tabs-row {
+    width: 100%;
+  }
+  .status-tab {
+    flex: 1 1 50%;
+    width: auto;
+  }
 }
 
 /* контейнер для поля + иконки */

--- a/src/pages/not-found/index.jsx
+++ b/src/pages/not-found/index.jsx
@@ -2,13 +2,11 @@
 
 import React from "react";
 import { Link } from "react-router-dom";
+import styles from "./styles.module.css";
 
 function NotFoundPage() {
   return (
-    <div
-      className="page not-found-page"
-      style={{ textAlign: "center", marginTop: "100px" }}
-    >
+    <div className={`page not-found-page ${styles["not-found-page"]}`}>
       <h2>404 — Страница не найдена</h2>
       <p>К сожалению, такой страницы не существует.</p>
       <p>

--- a/src/pages/not-found/styles.module.css
+++ b/src/pages/not-found/styles.module.css
@@ -1,0 +1,11 @@
+.not-found-page {
+  text-align: center;
+  padding-top: 100px;
+  padding-bottom: 40px;
+}
+@media (max-width: 600px) {
+  .not-found-page {
+    padding-top: 80px;
+    padding-bottom: 20px;
+  }
+}

--- a/src/pages/signup/index.module.css
+++ b/src/pages/signup/index.module.css
@@ -78,3 +78,14 @@
   margin-top: 16px;
   text-align: center;
 }
+@media (max-width: 600px) {
+  .auth-page {
+    padding-top: 80px;
+    padding-bottom: 20px;
+  }
+  .auth-form {
+    max-width: none;
+    width: 90%;
+    padding: 16px;
+  }
+}


### PR DESCRIPTION
## Summary
- add mobile layout rules for the header
- tweak footer layout on small screens
- make auth pages mobile friendly
- add mobile tweaks for booking and movie detail pages
- style the 404 page and hook up its CSS
- fix slider button and arrow placement for phones
- keep showtime cards from stretching on mobile
- limit showtime pills to three per row on phones
- adjust movies page controls for mobile and resize carousel arrows

## Testing
- `npm run prettier:check` *(fails: code style issues)*
- `CI=true npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b1ddabdc883229dd3f11167992bcd